### PR TITLE
PERF: Use DB for topic enumeration tasks

### DIFF
--- a/assets/javascripts/discourse/controllers/knowledge-explorer.js.es6
+++ b/assets/javascripts/discourse/controllers/knowledge-explorer.js.es6
@@ -66,9 +66,9 @@ export default Ember.Controller.extend({
     return !!searchTerm;
   },
 
-  @discourseComputed("isSearching", "topics")
-  searchCount(isSearching, topics) {
-    if (isSearching) return topics.length;
+  @discourseComputed("isSearching", "model")
+  searchCount(isSearching, model) {
+    if (isSearching) return model.search_count;
   },
 
   emptySearchResults: Ember.computed.equal("searchCount", 0),

--- a/assets/javascripts/discourse/controllers/knowledge-explorer.js.es6
+++ b/assets/javascripts/discourse/controllers/knowledge-explorer.js.es6
@@ -58,10 +58,7 @@ export default Ember.Controller.extend({
 
   @discourseComputed("loadMoreUrl")
   canLoadMore(loadMoreUrl) {
-    if (loadMoreUrl === null || this.isLoadingMore) {
-      return false;
-    }
-    return true;
+    return loadMoreUrl === null ? false : true;
   },
 
   @discourseComputed("searchTerm")
@@ -182,7 +179,7 @@ export default Ember.Controller.extend({
     },
 
     loadMore() {
-      if (this.canLoadMore) {
+      if (this.canLoadMore && !this.isLoadingMore) {
         this.set("isLoadingMore", true);
 
         KnowledgeExplorer.loadMore(this.loadMoreUrl).then(result => {

--- a/assets/javascripts/discourse/models/knowledge-explorer.js.es6
+++ b/assets/javascripts/discourse/models/knowledge-explorer.js.es6
@@ -42,7 +42,19 @@ export default {
   },
 
   loadMore(loadMoreUrl) {
-    return ajax(loadMoreUrl);
+    let promise = ajax(loadMoreUrl);
+
+    promise = promise.then(data => {
+      data.topics.topic_list.topics = data.topics.topic_list.topics.map(
+        topic => {
+          topic = Topic.create(topic);
+          return topic;
+        }
+      );
+      return data;
+    });
+
+    return promise;
   },
 
   getTopic

--- a/lib/knowledge_explorer/query.rb
+++ b/lib/knowledge_explorer/query.rb
@@ -89,7 +89,12 @@ module KnowledgeExplorer
         end
       end
 
-      tags = results.where("tags.name IS NOT NULL").group("tags.name").count
+      # conduct a second set of joins so we don't mess up the count
+      count_query = results.joins <<~SQL
+        INNER JOIN topic_tags tt2 ON tt2.topic_id = topics.id
+        INNER JOIN tags t2 ON t2.id = tt2.tag_id
+      SQL
+      tags = count_query.group('t2.name').count
       tags = create_tags_object(tags)
       categories = results.where('topics.category_id IS NOT NULL').group('topics.category_id').count
       categories = create_categories_object(categories)

--- a/lib/knowledge_explorer/query.rb
+++ b/lib/knowledge_explorer/query.rb
@@ -72,6 +72,7 @@ module KnowledgeExplorer
               pd.search_data @@ #{escaped_ts_query}
           )
         SQL
+        search_count = results.count
       end
 
       if @filters[:order] == "title"
@@ -118,7 +119,7 @@ module KnowledgeExplorer
         topic_list['load_more_url'] = nil
       end
 
-      { tags: tags, categories: categories, topics: topic_list }
+      { tags: tags, categories: categories, topics: topic_list, search_count: search_count }
     end
 
     def create_tags_object(tags)


### PR DESCRIPTION
We were loading every topic into memory, so for large datasets this blew up. 

@davidtaylorhq already ran through a review on this and gave the go-ahead so I'm going to merge.