### PR TITLE
FIX: Topics not always properly shown

### DIFF
--- a/app/controllers/knowledge_explorer/knowledge_explorer_controller.rb
+++ b/app/controllers/knowledge_explorer/knowledge_explorer_controller.rb
@@ -55,6 +55,7 @@ module KnowledgeExplorer
 
     def topic_in_explorer(category, tags)
       category_match = KnowledgeExplorer::Query.categories.include?(category.to_s)
+      tags = tags.pluck(:name)
       tag_match = KnowledgeExplorer::Query.tags.any? { |tag| tags.include?(tag) }
 
       category_match || tag_match

--- a/spec/requests/knowledge_explorer_controller_spec.rb
+++ b/spec/requests/knowledge_explorer_controller_spec.rb
@@ -154,6 +154,22 @@ describe KnowledgeExplorer::KnowledgeExplorerController do
 
         expect(response.parsed_body['topic']).to be_blank
       end
+
+      it 'should return a KE topic when only tags are added to settings' do
+        SiteSetting.knowledge_explorer_categories = nil
+
+        get "/docs.json?topic=#{topic.id}"
+
+        expect(response.parsed_body['topic']['id']).to eq(topic.id)
+      end
+
+      it 'should return a KE topic when only categories are added to settings' do
+        SiteSetting.knowledge_explorer_tags = nil
+
+        get "/docs.json?topic=#{topic.id}"
+
+        expect(response.parsed_body['topic']['id']).to eq(topic.id)
+      end
     end
   end
 end


### PR DESCRIPTION
There was a bug with the logic in how we were checking for matching tags and categories in KE settings. If only tags were set, topics would not show.

Also added some tests to check this in the future.