### PR TITLE
FIX: Query name collision with multiple filters

### DIFF
--- a/lib/knowledge_explorer/query.rb
+++ b/lib/knowledge_explorer/query.rb
@@ -37,7 +37,7 @@ module KnowledgeExplorer
         if tags_count == tag_filters.length
           tag_filters.each_with_index do |tag, index|
             # to_i to make it clear this is not an injection
-            sql_alias = "t#{index.to_i}"
+            sql_alias = "tt#{index.to_i}"
             results = results.joins("INNER JOIN topic_tags #{sql_alias} ON #{sql_alias}.topic_id = topics.id AND #{sql_alias}.tag_id = #{tag}")
           end
         else
@@ -91,8 +91,8 @@ module KnowledgeExplorer
 
       # conduct a second set of joins so we don't mess up the count
       count_query = results.joins <<~SQL
-        INNER JOIN topic_tags tt2 ON tt2.topic_id = topics.id
-        INNER JOIN tags t2 ON t2.id = tt2.tag_id
+        INNER JOIN topic_tags ttx ON ttx.topic_id = topics.id
+        INNER JOIN tags t2 ON t2.id = ttx.tag_id
       SQL
       tags = count_query.group('t2.name').count
       tags = create_tags_object(tags)

--- a/spec/requests/knowledge_explorer_controller_spec.rb
+++ b/spec/requests/knowledge_explorer_controller_spec.rb
@@ -63,16 +63,30 @@ describe KnowledgeExplorer::KnowledgeExplorerController do
     end
 
     context 'when filtering by tag' do
+      fab!(:tag2) { Fabricate(:tag, topics: [topic], name: 'test2') }
+      fab!(:tag3) { Fabricate(:tag, topics: [topic], name: 'test3') }
+
       it 'should return a list filtered by tag' do
         get '/docs.json?tags=test'
 
         expect(response.status).to eq(200)
 
         json = JSON.parse(response.body)
+        topics = json['topics']['topic_list']['topics']
+
+        expect(topics.size).to eq(1)
+      end
+
+      it 'should properly filter with more than two tags' do
+        get '/docs.json?tags=test%7ctest2%7ctest3'
+
+        expect(response.status).to eq(200)
+
+        json = response.parsed_body
         tags = json['tags']
         topics = json['topics']['topic_list']['topics']
 
-        expect(tags.size).to eq(1)
+        expect(tags.size).to eq(3)
         expect(topics.size).to eq(1)
       end
     end


### PR DESCRIPTION
https://meta.discourse.org/t/error-when-adding-3-or-4-filters-to-knowledge-explorer-plugin/167123/

If using more than two tags to filter, we'd run into an SQL alias
collision on a few joins. Resolved by ensuring unique names are used across the query.