### PR TITLE
DEV: Fix deprecated object creation methods

### DIFF
--- a/assets/javascripts/discourse/components/knowledge-explorer-category.js.es6
+++ b/assets/javascripts/discourse/components/knowledge-explorer-category.js.es6
@@ -1,6 +1,7 @@
+import Component from "@ember/component";
 import discourseComputed from "discourse-common/utils/decorators";
 
-export default Ember.Component.extend({
+export default Component.extend({
   tagName: "",
   @discourseComputed("category")
   categoryName(category) {

--- a/assets/javascripts/discourse/components/knowledge-explorer-search.js.es6
+++ b/assets/javascripts/discourse/components/knowledge-explorer-search.js.es6
@@ -1,6 +1,7 @@
+import Component from "@ember/component";
 import debounce from "discourse/lib/debounce";
 
-export default Ember.Component.extend({
+export default Component.extend({
   classNames: "knowledge-explorer-search",
 
   debouncedSearch: debounce(function (term) {

--- a/assets/javascripts/discourse/components/knowledge-explorer-tag.js.es6
+++ b/assets/javascripts/discourse/components/knowledge-explorer-tag.js.es6
@@ -1,4 +1,5 @@
-export default Ember.Component.extend({
+import Component from "@ember/component";
+export default Component.extend({
   tagName: "",
   actions: {
     selectTag() {

--- a/assets/javascripts/discourse/components/knowledge-explorer-topic-list.js.es6
+++ b/assets/javascripts/discourse/components/knowledge-explorer-topic-list.js.es6
@@ -1,6 +1,7 @@
+import Component from "@ember/component";
 import discourseComputed from "discourse-common/utils/decorators";
 
-export default Ember.Component.extend({
+export default Component.extend({
   classNames: "knowledge-explorer-topic-list",
   @discourseComputed("order")
   sortTitle(order) {

--- a/assets/javascripts/discourse/components/knowledge-explorer-topic.js.es6
+++ b/assets/javascripts/discourse/components/knowledge-explorer-topic.js.es6
@@ -1,7 +1,8 @@
+import Component from "@ember/component";
 import { reads } from "@ember/object/computed";
 import { computed } from "@ember/object";
 
-export default Ember.Component.extend({
+export default Component.extend({
   classNames: "knowledge-explorer-topic",
 
   originalPostContent: reads("post.cooked"),

--- a/assets/javascripts/discourse/controllers/knowledge-explorer.js.es6
+++ b/assets/javascripts/discourse/controllers/knowledge-explorer.js.es6
@@ -1,3 +1,4 @@
+import Controller from "@ember/controller";
 import discourseComputed from "discourse-common/utils/decorators";
 import Category from "discourse/models/category";
 import { on } from "discourse-common/utils/decorators";
@@ -16,7 +17,7 @@ function mergeCategories(results) {
   return results;
 }
 
-export default Ember.Controller.extend({
+export default Controller.extend({
   application: Ember.inject.controller(),
   queryParams: {
     ascending: "ascending",

--- a/assets/javascripts/discourse/models/knowledge-explorer.js.es6
+++ b/assets/javascripts/discourse/models/knowledge-explorer.js.es6
@@ -1,7 +1,10 @@
+import EmberObject from "@ember/object";
 import { ajax } from "discourse/lib/ajax";
 import Topic from "discourse/models/topic";
 
-export default {
+const KnowledgeExplorer = EmberObject.extend({});
+
+KnowledgeExplorer.reopenClass({
   list(params) {
     let filters = [];
     if (params.filterCategories) {
@@ -60,4 +63,6 @@ export default {
 
     return promise;
   },
-};
+});
+
+export default KnowledgeExplorer;

--- a/assets/javascripts/discourse/routes/knowledge-explorer.js.es6
+++ b/assets/javascripts/discourse/routes/knowledge-explorer.js.es6
@@ -1,7 +1,8 @@
+import Route from "@ember/routing/route";
 import Category from "discourse/models/category";
 import KnowledgeExplorer from "discourse/plugins/discourse-knowledge-explorer/discourse/models/knowledge-explorer";
 
-export default Ember.Route.extend({
+export default Route.extend({
   queryParams: {
     searchTerm: {
       replace: true,


### PR DESCRIPTION
This had been hanging in the black hole of my todo list for a while -- needed to fix the deprecated methods of creating Ember classes and objects. This PR handles that job.