### PR TITLE
FIX: Sort query was ambiguous

### DIFF
--- a/lib/knowledge_explorer/query.rb
+++ b/lib/knowledge_explorer/query.rb
@@ -83,9 +83,9 @@ module KnowledgeExplorer
         end
       elsif @filters[:order] == "activity"
         if @filters[:ascending].present?
-          results = results.reorder('last_posted_at')
+          results = results.reorder('topics.last_posted_at')
         else
-          results = results.reorder('last_posted_at DESC')
+          results = results.reorder('topics.last_posted_at DESC')
         end
       end
 

--- a/lib/knowledge_explorer/query.rb
+++ b/lib/knowledge_explorer/query.rb
@@ -77,9 +77,9 @@ module KnowledgeExplorer
 
       if @filters[:order] == "title"
         if @filters[:ascending].present?
-          results = results.reorder('title')
+          results = results.reorder('topics.title')
         else
-          results = results.reorder('title DESC')
+          results = results.reorder('topics.title DESC')
         end
       elsif @filters[:order] == "activity"
         if @filters[:ascending].present?

--- a/spec/requests/knowledge_explorer_controller_spec.rb
+++ b/spec/requests/knowledge_explorer_controller_spec.rb
@@ -113,6 +113,64 @@ describe KnowledgeExplorer::KnowledgeExplorerController do
       end
     end
 
+    context 'when ordering results' do
+      context 'by title' do
+        it 'should return the list ordered descending' do
+          get "/docs.json?order=title"
+
+          expect(response.status).to eq(200)
+
+          json = response.parsed_body
+          topics = json['topics']['topic_list']['topics']
+
+          expect(topics[0]['id']).to eq(topic2.id)
+          expect(topics[1]['id']).to eq(topic.id)
+        end
+
+        it 'should return the list ordered ascending with an additional parameter' do
+          get "/docs.json?order=title&ascending=true"
+
+          expect(response.status).to eq(200)
+
+          json = response.parsed_body
+          topics = json['topics']['topic_list']['topics']
+
+          expect(topics[0]['id']).to eq(topic.id)
+          expect(topics[1]['id']).to eq(topic2.id)
+        end
+      end
+
+      context 'by date' do
+        before do
+          topic2.update(last_posted_at: Time.new + 100)
+        end
+
+        it 'should return the list ordered descending' do
+          get "/docs.json?order=activity"
+
+          expect(response.status).to eq(200)
+
+          json = response.parsed_body
+          topics = json['topics']['topic_list']['topics']
+
+          expect(topics[0]['id']).to eq(topic.id)
+          expect(topics[1]['id']).to eq(topic2.id)
+        end
+
+        it 'should return the list ordered ascending with an additional parameter' do
+          get "/docs.json?order=activity&ascending=true"
+
+          expect(response.status).to eq(200)
+
+          json = response.parsed_body
+          topics = json['topics']['topic_list']['topics']
+
+          expect(topics[0]['id']).to eq(topic2.id)
+          expect(topics[1]['id']).to eq(topic.id)
+        end
+      end
+    end
+
     context 'when searching' do
       before do
         SearchIndexer.enable

--- a/spec/requests/knowledge_explorer_controller_spec.rb
+++ b/spec/requests/knowledge_explorer_controller_spec.rb
@@ -142,7 +142,7 @@ describe KnowledgeExplorer::KnowledgeExplorerController do
 
       context 'by date' do
         before do
-          topic2.update(last_posted_at: Time.new + 100)
+          topic2.update(last_posted_at: Time.zone.now + 100)
         end
 
         it 'should return the list ordered descending' do


### PR DESCRIPTION
After implementing changes to tagging, this introduced ambiguity in the SQL query for sorting by activity. This commit fixes the ambiguity by explicitly defining the table from where the columns are used. Also adds tests to check for regressions in the future.