### PR TITLE
FIX: flaky order in spec

### DIFF
--- a/spec/requests/knowledge_explorer_controller_spec.rb
+++ b/spec/requests/knowledge_explorer_controller_spec.rb
@@ -4,8 +4,8 @@ require 'rails_helper'
 
 describe KnowledgeExplorer::KnowledgeExplorerController do
   fab!(:category) { Fabricate(:category) }
-  fab!(:topic) { Fabricate(:topic, category: category) }
-  fab!(:topic2) { Fabricate(:topic, category: category) }
+  fab!(:topic) { Fabricate(:topic, title: "I love carrot today", category: category) }
+  fab!(:topic2) { Fabricate(:topic, title: "I love pineapple today", category: category) }
   fab!(:tag) { Fabricate(:tag, topics: [topic], name: 'test') }
 
   before do


### PR DESCRIPTION
In Spec we were creating two topics:
```ruby
  fab!(:topic) { Fabricate(:topic, category: category) }
  fab!(:topic2) { Fabricate(:topic, category: category) }
```

Because we didn't set title explicitly it was using sequence from Fabricator
```ruby
  title { sequence(:title) { |i| "This is a test topic #{i}" } }
```

If you have two titles `This is a test topic 9` and `This is a test topic 10` Spec testing if topics are sorted will fail. 

Therefore, we should explicitly set topic title when creating test instances to avoid that randomness.