### PR TITLE
FIX: Don't overwrite Topic.category computed prop

### DIFF
--- a/assets/javascripts/discourse/controllers/knowledge-explorer-index.js.es6
+++ b/assets/javascripts/discourse/controllers/knowledge-explorer-index.js.es6
@@ -1,6 +1,5 @@
 import Controller from "@ember/controller";
 import discourseComputed from "discourse-common/utils/decorators";
-import Category from "discourse/models/category";
 import { on } from "discourse-common/utils/decorators";
 import KnowledgeExplorer from "discourse/plugins/discourse-knowledge-explorer/discourse/models/knowledge-explorer";
 import { getOwner } from "@ember/application";

--- a/assets/javascripts/discourse/controllers/knowledge-explorer-index.js.es6
+++ b/assets/javascripts/discourse/controllers/knowledge-explorer-index.js.es6
@@ -5,18 +5,6 @@ import { on } from "discourse-common/utils/decorators";
 import KnowledgeExplorer from "discourse/plugins/discourse-knowledge-explorer/discourse/models/knowledge-explorer";
 import { getOwner } from "@ember/application";
 
-function mergeCategories(results) {
-  const categories = Category.list();
-  const topics = results.topics.topic_list.topics.map((t) => {
-    t.category = categories.findBy("id", t.category_id);
-    return t;
-  });
-
-  results.topics.topic_list.topics = topics;
-
-  return results;
-}
-
 export default Controller.extend({
   queryParams: {
     ascending: "ascending",
@@ -184,7 +172,6 @@ export default Controller.extend({
         this.set("isLoadingMore", true);
 
         KnowledgeExplorer.loadMore(this.loadMoreUrl).then((result) => {
-          result = mergeCategories(result);
           const topics = this.topics.concat(result.topics.topic_list.topics);
 
           this.setProperties({

--- a/assets/javascripts/discourse/routes/knowledge-explorer-index.js.es6
+++ b/assets/javascripts/discourse/routes/knowledge-explorer-index.js.es6
@@ -24,17 +24,6 @@ export default Route.extend({
   },
 
   setupController(controller, model) {
-    const categories = Category.list();
-
-    let topics = model.topics.topic_list.topics;
-
-    topics = topics.map((t) => {
-      t.category = categories.findBy("id", t.category_id);
-      return t;
-    });
-
-    model.topics.topic_list.topics = topics;
-
     controller.set("topic", model.topic);
     controller.set("model", model);
   },

--- a/assets/javascripts/discourse/routes/knowledge-explorer-index.js.es6
+++ b/assets/javascripts/discourse/routes/knowledge-explorer-index.js.es6
@@ -1,5 +1,4 @@
 import Route from "@ember/routing/route";
-import Category from "discourse/models/category";
 import KnowledgeExplorer from "discourse/plugins/discourse-knowledge-explorer/discourse/models/knowledge-explorer";
 
 export default Route.extend({


### PR DESCRIPTION
Pre-loading/pre-assigning isn't necessary. `Topic.category` uses `Category.findById` which in turn uses an identity map, so there are no N+1 calls to the backend.