### PR TITLE
FIX: Show muted topics

### DIFF
--- a/lib/knowledge_explorer/query.rb
+++ b/lib/knowledge_explorer/query.rb
@@ -18,9 +18,11 @@ module KnowledgeExplorer
 
     def list
       # query for topics matching selected categories & tags
-      tq = TopicQuery.new(@user)
-      results = tq.latest_results(no_definitions: true, limit: false)
+      opts = { no_definitions: true, limit: false }
+      tq = TopicQuery.new(@user, opts)
+      results = tq.list_knowledge_explorer_topics
       results = results.left_outer_joins(:tags)
+      results = results.references(:categories)
       results = results.where('topics.category_id IN (?)', Query.categories).or(results.where('tags.name IN (?)', Query.tags))
 
       # filter results by selected category

--- a/plugin.rb
+++ b/plugin.rb
@@ -34,4 +34,7 @@ after_initialize do
       end
     end
   end
+  add_to_class(:topic_query, :list_knowledge_explorer_topics) do
+    default_results(@options)
+  end
 end


### PR DESCRIPTION
In many cases it makes sense to show muted topics in the Knowledge Explorer view. One such case might be if a user mutes a documentation category, but wants to be able to search them via this plugin. 

To implement this, I've called `TopicQuery.default_results` via an added class method, which does the same thing as `latest_results` except skips the muted topics removal.

One issue I ran into with this is with the `no_definitions` option set to `true`, the query was not able to see the `categories` table. This appears to work correctly in core as I dug into it, but was not able to root out the source of the issue in the plugin. Everything seems to be generated correctly compared to how core methods use `TopicQuery`, but this issue remained. This is the reason for the `results.references(:categories)` call on line 25 of `query.rb`, as then the query can properly access the `categories` table.

Regarding testing, I didn't include a spec to test for muted topics being included as we do not currently test for this in core from what I could find.