### PR TITLE
FIX: Results count not always properly shown

### DIFF
--- a/assets/javascripts/discourse/controllers/knowledge-explorer-index.js.es6
+++ b/assets/javascripts/discourse/controllers/knowledge-explorer-index.js.es6
@@ -1,5 +1,7 @@
 import Controller from "@ember/controller";
+import { inject } from "@ember/controller";
 import discourseComputed from "discourse-common/utils/decorators";
+import { alias, readOnly, equal } from "@ember/object/computed";
 import { on } from "discourse-common/utils/decorators";
 import KnowledgeExplorer from "discourse/plugins/discourse-knowledge-explorer/discourse/models/knowledge-explorer";
 import { getOwner } from "@ember/application";
@@ -14,14 +16,14 @@ export default Controller.extend({
     searchTerm: "search",
     selectedTopic: "topic",
   },
-  application: Ember.inject.controller(),
+  application: inject(),
   isLoading: false,
   isLoadingMore: false,
-  loadMoreUrl: Ember.computed.alias("model.topics.load_more_url"),
+  loadMoreUrl: alias("model.topics.load_more_url"),
   isTopicLoading: false,
-  categories: Ember.computed.readOnly("model.categories"),
-  topics: Ember.computed.alias("model.topics.topic_list.topics"),
-  tags: Ember.computed.readOnly("model.tags"),
+  categories: readOnly("model.categories"),
+  topics: alias("model.topics.topic_list.topics"),
+  tags: readOnly("model.tags"),
   filterTags: null,
   filterCategories: null,
   filterSolved: false,
@@ -31,7 +33,7 @@ export default Controller.extend({
   expandedFilters: false,
   ascending: null,
   orderColumn: null,
-  topicCount: Ember.computed.alias("model.topic_count"),
+  topicCount: alias("model.topic_count"),
 
   @on("init")
   _setupFilters() {
@@ -61,7 +63,7 @@ export default Controller.extend({
     return isSearching || filterSolved;
   },
 
-  emptyResults: Ember.computed.equal("topicCount", 0),
+  emptyResults: equal("topicCount", 0),
 
   @discourseComputed
   canFilterSolved() {

--- a/assets/javascripts/discourse/controllers/knowledge-explorer-index.js.es6
+++ b/assets/javascripts/discourse/controllers/knowledge-explorer-index.js.es6
@@ -31,6 +31,7 @@ export default Controller.extend({
   expandedFilters: false,
   ascending: null,
   orderColumn: null,
+  topicCount: Ember.computed.alias("model.topic_count"),
 
   @on("init")
   _setupFilters() {
@@ -42,7 +43,7 @@ export default Controller.extend({
   @discourseComputed("topics", "isSearching", "filterSolved")
   emptyTopics(topics, isSearching, filterSolved) {
     const filtered = isSearching || filterSolved;
-    return topics.length === 0 && !filtered;
+    return this.topicCount === 0 && !filtered;
   },
 
   @discourseComputed("loadMoreUrl")
@@ -60,24 +61,7 @@ export default Controller.extend({
     return isSearching || filterSolved;
   },
 
-  @discourseComputed("isSearching", "model")
-  searchCount(isSearching, model) {
-    if (isSearching) {
-      return model.search_count;
-    }
-  },
-
-  emptySearchResults: Ember.computed.equal("searchCount", 0),
-
-  @discourseComputed("topics")
-  emptyFilteredResults(topics) {
-    return topics.length === 0;
-  },
-
-  @discourseComputed("emptySearchResults", "emptyFilteredResults")
-  emptyResults(emptySearch, emptyFiltered) {
-    return emptySearch || emptyFiltered;
-  },
+  emptyResults: Ember.computed.equal("topicCount", 0),
 
   @discourseComputed
   canFilterSolved() {
@@ -134,6 +118,7 @@ export default Controller.extend({
         selectedTopic: null,
       });
     },
+
     performSearch(term) {
       if (term === "") {
         this.set("searchTerm", null);

--- a/assets/javascripts/discourse/controllers/knowledge-explorer.js.es6
+++ b/assets/javascripts/discourse/controllers/knowledge-explorer.js.es6
@@ -1,7 +1,8 @@
 import Controller from "@ember/controller";
+import { inject } from "@ember/controller";
 
 export default Controller.extend({
-  indexController: Ember.inject.controller("knowledgeExplorer.index"),
+  indexController: inject("knowledgeExplorer.index"),
   actions: {
     updateSelectedCategories(category) {
       this.indexController.send("updateSelectedCategories", category);

--- a/assets/javascripts/discourse/templates/knowledge-explorer-index.hbs
+++ b/assets/javascripts/discourse/templates/knowledge-explorer-index.hbs
@@ -63,7 +63,7 @@
           {{else}}
             <div class="result-count">
               {{i18n 'knowledge_explorer.search.results'
-                count=searchCount
+                count=topicCount
               }}
             </div>
           {{/if}}

--- a/lib/knowledge_explorer/query.rb
+++ b/lib/knowledge_explorer/query.rb
@@ -74,7 +74,6 @@ module KnowledgeExplorer
               pd.search_data @@ #{escaped_ts_query}
           )
         SQL
-        search_count = results.size
       end
 
       if @filters[:order] == "title"
@@ -126,7 +125,7 @@ module KnowledgeExplorer
         topic_list['load_more_url'] = nil
       end
 
-      { tags: tags, categories: categories, topics: topic_list, search_count: search_count }
+      { tags: tags, categories: categories, topics: topic_list, topic_count: results_length }
     end
 
     def create_tags_object(tags)

--- a/spec/requests/knowledge_explorer_controller_spec.rb
+++ b/spec/requests/knowledge_explorer_controller_spec.rb
@@ -29,6 +29,15 @@ describe KnowledgeExplorer::KnowledgeExplorerController do
         expect(tags.size).to eq(1)
         expect(topics.size).to eq(2)
       end
+
+      it 'should return a topic count' do
+        get '/docs.json'
+
+        json = response.parsed_body
+        topic_count = json['topic_count']
+
+        expect(topic_count).to eq(2)
+      end
     end
 
     context 'when some knowledge explorer topics are private' do


### PR DESCRIPTION
There was a weird case where when filtering topics by solved status did not properly show the count of filtered topics. I took this opportunity to lightly refactor the backend. There was a duplicate size operation when we searched and when calculating pagination. I've eliminated the second size call and refactored the front end to be a little bit simpler while solving the bug.

Also tried to create a 2nd PR from another branch for the import transition commit below but somehow that wasn't done correctly. Sorry about that.