### PR TITLE
DEV: Use the new discourseDebounce function wrapper.

### DIFF
--- a/assets/javascripts/discourse/components/knowledge-explorer-search.js.es6
+++ b/assets/javascripts/discourse/components/knowledge-explorer-search.js.es6
@@ -1,12 +1,22 @@
 import Component from "@ember/component";
-import debounce from "discourse/lib/debounce";
+import { debounce } from "@ember/runloop";
+import discourseDebounce from "discourse-common/lib/debounce";
 
 export default Component.extend({
   classNames: "knowledge-explorer-search",
 
-  debouncedSearch: debounce(function (term) {
-    this.onSearch(term);
-  }, 500),
+  debouncedSearch(term) {
+    // TODO: Use discouseDebounce when discourse 2.7 gets released.
+    const debounceFunc = discourseDebounce || debounce;
+
+    debounceFunc(
+      this,
+      function () {
+        this.onSearch(term);
+      },
+      500
+    );
+  },
 
   actions: {
     onSearchTermChange(term) {


### PR DESCRIPTION
We recently merged a Discourse core's PR to replace usages of Ember's debounce and discourseDebounce with a new debounce wrapper. The new wrapper works exactly like Ember's debounce but internally calls "run" when called in test mode.

This PR replaces all usages of other debounce functions with the new wrapper and fallbacks to Ember's debounce for backward-compatibility.