### PR TITLE
FIX: debounce search correctly

### DIFF
--- a/assets/javascripts/discourse/components/knowledge-explorer-search.js.es6
+++ b/assets/javascripts/discourse/components/knowledge-explorer-search.js.es6
@@ -9,13 +9,7 @@ export default Component.extend({
     // TODO: Use discouseDebounce when discourse 2.7 gets released.
     const debounceFunc = discourseDebounce || debounce;
 
-    debounceFunc(
-      this,
-      function () {
-        this.onSearch(term);
-      },
-      500
-    );
+    debounceFunc(this, "onSearch", term, 500);
   },
 
   actions: {


### PR DESCRIPTION
`debounce` doesn't work correctly if it's given a new instance of the callback function each time it's called. The knowledge explorer search bar is currently broken because of that.

Signed-off-by: OsamaSayegh <asooomaasoooma90@gmail.com>