### PR TITLE
FIX: Show unicode title in topic view

### DIFF
--- a/assets/javascripts/discourse/templates/components/knowledge-explorer-topic.hbs
+++ b/assets/javascripts/discourse/templates/components/knowledge-explorer-topic.hbs
@@ -5,7 +5,7 @@
 }}
 
 <div class="topic-content">
-  <h1>{{topic.title}}</h1>
+  <h1>{{topic.unicode_title}}</h1>
   {{mount-widget
     widget="post"
     model=model


### PR DESCRIPTION
Topic titles with unicode elements were displaying uncooked.